### PR TITLE
fix: Pin numpy version and update Install.sh to v4.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ python-telegram-bot==13.15
 urllib3==1.26.18 # Pinned for stability, as seen in Install.sh
 
 # Data Processing & Analysis
-pandas~=1.5.0 # Compatible release with 1.5
-numpy>=1.23.0 # Use a more recent version compatible with newer Python
+pandas==2.0.3 # Pinned for Python 3.12 compatibility
+numpy==1.26.4 # Pinned for specific compatibility needs
 requests~=2.28.0 # Compatible release with 2.28
 joblib~=1.1.0 # For saving/loading AI models or other objects
 


### PR DESCRIPTION
- Pinned numpy to version 1.26.4 in requirements.txt for specific Python 3.12 compatibility needs, in addition to pandas==2.0.3.
- Updated Install.sh internal version to v4.4 to reflect latest changes.